### PR TITLE
Feature: Hide chat status from other players

### DIFF
--- a/src/engine/shared/chillerbot/variables.h
+++ b/src/engine/shared/chillerbot/variables.h
@@ -43,6 +43,7 @@ MACRO_CONFIG_INT(ClDbgIntersect, cl_dbg_intersect, 0, 0, 1, CFGFLAG_CLIENT, "Sho
 MACRO_CONFIG_INT(ClReleaseMouse, cl_release_mouse, 0, 0, 1, CFGFLAG_CLIENT, "Release the mouse (you probably do not want this)")
 MACRO_CONFIG_STR(ClRunOnVoteStart, cl_run_on_vote_start, 512, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "console command to run when a vote is called")
 MACRO_CONFIG_INT(ClMineTeeEditor, cl_mine_tee_editor, 0, 0, 1, CFGFLAG_CLIENT, "send modify map packets to the server while brushing in the editor")
+MACRO_CONFIG_INT(ClHideChatBubble, cl_hide_chat_bubble, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Hide chat status from other players")
 
 #if defined(CONF_CURSES_CLIENT)
 MACRO_CONFIG_INT(ClTermHistory, cl_term_history, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Persist input history in filesystem for curses client")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -181,12 +181,16 @@ void CControls::OnMessage(int Msg, void *pRawMsg)
 int CControls::SnapInput(int *pData)
 {
 	// update player state
-	if(m_pClient->m_Chat.IsActive())
-		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags = PLAYERFLAG_CHATTING;
-	else if(m_pClient->m_Menus.IsActive())
-		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags = PLAYERFLAG_IN_MENU;
-	else
-		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags = PLAYERFLAG_PLAYING;
+  if(g_Config.m_ClHideChatBubble)
+    m_aInputData[g_Config.m_ClDummy].m_PlayerFlags &= ~PLAYERFLAG_CHATTING;
+
+  if(m_pClient->m_Chat.IsActive() && !g_Config.m_ClHideChatBubble)
+    m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_CHATTING;
+
+  else if(m_pClient->m_Menus.IsActive())
+    m_aInputData[g_Config.m_ClDummy].m_PlayerFlags = PLAYERFLAG_IN_MENU;
+  else
+    m_aInputData[g_Config.m_ClDummy].m_PlayerFlags = PLAYERFLAG_PLAYING;
 
 	if(m_pClient->m_Scoreboard.Active())
 		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_SCOREBOARD;

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -38,6 +38,8 @@ public:
 	void EyeEmote(int EyeEmote);
 
 	bool IsActive() const { return m_Active; }
+
+	bool IsTyping() const { return m_Active; }
 };
 
 #endif

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -748,15 +748,13 @@ void CPlayers::RenderPlayer(
 
 	int QuadOffsetToEmoticon = NUM_WEAPONS * 2 + 2 + 2;
 	if((Player.m_PlayerFlags & PLAYERFLAG_CHATTING) && !m_pClient->m_aClients[ClientId].m_Afk)
-	{
-		int CurEmoticon = (SPRITE_DOTDOT - SPRITE_OOP);
-		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[CurEmoticon]);
-		int QuadOffset = QuadOffsetToEmoticon + CurEmoticon;
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
-		Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffset, Position.x + 24.f, Position.y - 40.f);
-
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		Graphics()->QuadsSetRotation(0);
+{
+		if(!g_Config.m_ClHideChatBubble)
+		{
+			int CurEmoticon = (SPRITE_DOTDOT - SPRITE_OOP);
+			Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[CurEmoticon]);
+			Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffsetToEmoticon + CurEmoticon, Position.x + 24.f, Position.y - 40.f);
+		}
 	}
 
 	if(g_Config.m_ClAfkEmote && m_pClient->m_aClients[ClientId].m_Afk && !(Client()->DummyConnected() && ClientId == m_pClient->m_aLocalIds[!g_Config.m_ClDummy]))

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -199,6 +199,8 @@ public:
 	CTerminalUI m_TerminalUI;
 	CStresser m_Stresser;
 
+	const CEmoticon *Emoticon() const { return &m_Emoticon; }
+
 private:
 	std::vector<class CComponent *> m_vpAll;
 	std::vector<class CComponent *> m_vpInput;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The new feature adds the ability for players to hide their chat status from others using the cl_hide_chat_bubble command. This enhancement allows players to maintain privacy and avoid distractions by choosing not to display their chat bubble to others in the game.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
I have implemented the feature to hide the chat status using the cl_hide_chat_bubble command. However, I did not integrate this feature into the HUD. If there's interest in adding this functionality to the HUD, it can be done in a future enhancement or by another contributor. I'm open to feedback and further discussion on how this feature can be improved or extended.

## Checklist

- [x ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
