### PR TITLE
Change implementation of custom client identification

### DIFF
--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -251,7 +251,7 @@ int CChillerBotUX::ReplaceCountryFlagWithCustomClientId(int Country)
 // function originally from Kaizo Network by +KZ, credit if used
 bool CChillerBotUX::IsCustomClientId(int Country)
 {
-	return Country == CUSTOM_CLIENT_ID_KAIZO_NETWORK || Country == CUSTOM_CLIENT_ID_CHILLERBOTUX;
+	return Country > GameClient()->m_CountryFlags.Num();
 }
 
 // code originally from Kaizo Network by +KZ, credit if used

--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -231,60 +231,40 @@ int CChillerBotUX::GetPlayTimeHours() const
 }
 
 // function originally from Kaizo Network by +KZ, credit if used
-int CChillerBotUX::InsertArbitraryClientFlagInCountry(int Country)
+int CChillerBotUX::ReplaceCountryFlagWithCustomClientId(int Country)
 {
-	if(!g_Config.m_ClSendClientType)
-		return Country;
+    if(!g_Config.m_ClSendClientType)
+        return Country;
 
-	if(m_SendingCustomClientTicks <= 1) //dont send custom flag
-		return Country;
+    if(m_SendingCustomClientTicks <= 1) //dont send custom flag
+        return Country;
 
-	UCountryData CountryFlagsNum;
-	CountryFlagsNum.m_IntData = GameClient()->m_CountryFlags.Num();
+    //if some random day amount of flags conflicts with invalid flag, just send normal country
+    if(GameClient()->m_CountryFlags.Num() >= CUSTOM_CLIENT_ID_KAIZO_NETWORK) 
+    {
+        return Country;
+    }
 
-	//if some day amount of flags conflicts with arbitrary flag, just send normal country
-	if(CountryFlagsNum.m_aCharArbitraryData[3])
-	{
-		return Country;
-	}
-
-	//insert arbitrary byte
-	UCountryData CountryData;
-
-	CountryData.m_IntData = Country;
-	//(+KZ note: this may be removing negative bit, may need improvement,
-	// but is not a big problem since custom flag is only sent 1 time)
-	CountryData.m_aCharArbitraryData[3] = CUSTOM_CLIENT_ID_CHILLERBOTUX; //2 = CHILLERBOT-UX
-
-	return CountryData.m_IntData;
+	return CUSTOM_CLIENT_ID_CHILLERBOTUX;
 }
 
 // function originally from Kaizo Network by +KZ, credit if used
-int CChillerBotUX::RemoveArbitraryClientFlagFromCountry(int Country)
+bool CChillerBotUX::IsCustomClientId(int Country)
 {
-	UCountryData CountryData;
-
-	CountryData.m_IntData = Country;
-	//(+KZ note: this may be removing negative bit, may need improvement,
-	// but is not a big problem since custom flag is only sent 1 time)
-	CountryData.m_aCharArbitraryData[3] = 0; // clear byte
-
-	return CountryData.m_IntData;
+	return Country == CUSTOM_CLIENT_ID_KAIZO_NETWORK || Country == CUSTOM_CLIENT_ID_CHILLERBOTUX;
 }
 
-void CChillerBotUX::HandleCustomClientBytes(int Country, int ClientId)
+// code originally from Kaizo Network by +KZ, credit if used
+int CChillerBotUX::HandleClientCountry(int Country, int ClientId)
 {
-	if(m_aClientData[ClientId].m_CustomClient) // read normally if custom client already set
+	if(IsCustomClientId(Country)) //if it is a custom client id, set custom client id and keep country
 	{
-		return;
+		m_aClientData[ClientId].m_CustomClient = Country;
+		return GameClient()->m_aClients[ClientId].m_Country;
 	}
-	else
+	else //otherwise, set country
 	{
-		CChillerBotUX::UCountryData TempCountryData;
-		TempCountryData.m_IntData = Country;
-		GameClient()->m_aClients[ClientId].m_Country = RemoveArbitraryClientFlagFromCountry(TempCountryData.m_IntData);
-		//+KZ: get arbitrary custom client byte
-		m_aClientData[ClientId].m_CustomClient = TempCountryData.m_aCharArbitraryData[3];
+		return Country;
 	}
 }
 
@@ -1527,6 +1507,6 @@ int CChillerBotUX::GetUnusedJumps()
 
 void CChillerBotUX::CChillerClientData::Reset()
 {
-	m_CustomClient = '\0';
+	m_CustomClient = 0;
 	m_SentCustomClient = false;
 }

--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -233,17 +233,17 @@ int CChillerBotUX::GetPlayTimeHours() const
 // function originally from Kaizo Network by +KZ, credit if used
 int CChillerBotUX::ReplaceCountryFlagWithCustomClientId(int Country)
 {
-    if(!g_Config.m_ClSendClientType)
-        return Country;
+	if(!g_Config.m_ClSendClientType)
+		return Country;
 
-    if(m_SendingCustomClientTicks <= 1) //dont send custom flag
-        return Country;
+	if(m_SendingCustomClientTicks <= 1) //dont send custom flag
+		return Country;
 
-    //if some random day amount of flags conflicts with invalid flag, just send normal country
-    if(GameClient()->m_CountryFlags.Num() >= CUSTOM_CLIENT_ID_KAIZO_NETWORK) 
-    {
-        return Country;
-    }
+	//if some random day amount of flags conflicts with invalid flag, just send normal country
+	if(GameClient()->m_CountryFlags.Num() >= CUSTOM_CLIENT_ID_KAIZO_NETWORK)
+	{
+		return Country;
+	}
 
 	return CUSTOM_CLIENT_ID_CHILLERBOTUX;
 }

--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -251,7 +251,7 @@ int CChillerBotUX::ReplaceCountryFlagWithCustomClientId(int Country)
 // function originally from Kaizo Network by +KZ, credit if used
 bool CChillerBotUX::IsCustomClientId(int Country)
 {
-	return Country > GameClient()->m_CountryFlags.Num();
+	return (size_t)Country > GameClient()->m_CountryFlags.Num();
 }
 
 // code originally from Kaizo Network by +KZ, credit if used

--- a/src/game/client/components/chillerbot/chillerbotux.h
+++ b/src/game/client/components/chillerbot/chillerbotux.h
@@ -140,7 +140,7 @@ public:
 	class CChillerClientData
 	{
 	public:
-		char m_CustomClient = '\0'; //chillerbot
+		int m_CustomClient = 0; //chillerbot
 		bool m_SentCustomClient = false; //chillerbot
 
 		void Reset();
@@ -188,17 +188,10 @@ public:
 	int GetUnusedJumps();
 	int GetPlayTimeHours() const;
 
-	//+KZ: union to detect other custom clients by inserting data in the empty country bytes
-	union UCountryData
-	{
-		int m_IntData = 0;
-		unsigned char m_aCharArbitraryData[sizeof(int)];
-	};
-
-	int InsertArbitraryClientFlagInCountry(int Country);
-	int RemoveArbitraryClientFlagFromCountry(int Country);
+	int ReplaceCountryFlagWithCustomClientId(int Country);
+	bool IsCustomClientId(int Country);
 	int m_SendingCustomClientTicks = -1;
-	void HandleCustomClientBytes(int Country, int ClientId);
+	int HandleClientCountry(int Country, int ClientId);
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1740,8 +1740,7 @@ void CGameClient::OnNewSnapshot()
 						str_copy(pClient->m_aName, "nameless tee");
 					}
 					IntsToStr(pInfo->m_aClan, std::size(pInfo->m_aClan), pClient->m_aClan, std::size(pClient->m_aClan));
-					pClient->m_Country = pInfo->m_Country;
-					m_ChillerBotUX.HandleCustomClientBytes(pClient->m_Country, ClientId);
+					pClient->m_Country = m_ChillerBotUX.HandleClientCountry(pInfo->m_Country, ClientId);
 
 					IntsToStr(pInfo->m_aSkin, std::size(pInfo->m_aSkin), pClient->m_aSkinName, std::size(pClient->m_aSkinName));
 					if(!CSkin::IsValidName(pClient->m_aSkinName) ||
@@ -3012,7 +3011,7 @@ void CGameClient::SendStartInfo7(bool Dummy)
 	protocol7::CNetMsg_Cl_StartInfo Msg;
 	Msg.m_pName = Dummy ? Client()->DummyName() : Client()->PlayerName();
 	Msg.m_pClan = Dummy ? Config()->m_ClDummyClan : Config()->m_PlayerClan;
-	Msg.m_Country = m_ChillerBotUX.InsertArbitraryClientFlagInCountry(Dummy ? Config()->m_ClDummyCountry : Config()->m_PlayerCountry); // chillerbot modified
+	Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(Dummy ? Config()->m_ClDummyCountry : Config()->m_PlayerCountry); // chillerbot modified
 	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
 	{
 		Msg.m_apSkinPartNames[p] = CSkins7::ms_apSkinVariables[(int)Dummy][p];
@@ -3097,7 +3096,7 @@ void CGameClient::SendInfo(bool Start)
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
-		Msg.m_Country = m_ChillerBotUX.InsertArbitraryClientFlagInCountry(g_Config.m_PlayerCountry); // chillerbot modified
+		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_PlayerCountry); // chillerbot modified
 		Msg.m_pSkin = g_Config.m_ClPlayerSkin;
 		Msg.m_UseCustomColor = g_Config.m_ClPlayerUseCustomColor;
 		Msg.m_ColorBody = g_Config.m_ClPlayerColorBody;
@@ -3112,7 +3111,7 @@ void CGameClient::SendInfo(bool Start)
 		CNetMsg_Cl_ChangeInfo Msg;
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
-		Msg.m_Country = m_ChillerBotUX.InsertArbitraryClientFlagInCountry(g_Config.m_PlayerCountry); // chillerbot modified
+		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_PlayerCountry); // chillerbot modified
 		Msg.m_pSkin = g_Config.m_ClPlayerSkin;
 		Msg.m_UseCustomColor = g_Config.m_ClPlayerUseCustomColor;
 		Msg.m_ColorBody = g_Config.m_ClPlayerColorBody;
@@ -3139,7 +3138,7 @@ void CGameClient::SendDummyInfo(bool Start)
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
-		Msg.m_Country = m_ChillerBotUX.InsertArbitraryClientFlagInCountry(g_Config.m_ClDummyCountry); // chillerbot modified
+		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_ClDummyCountry); // chillerbot modified
 		Msg.m_pSkin = g_Config.m_ClDummySkin;
 		Msg.m_UseCustomColor = g_Config.m_ClDummyUseCustomColor;
 		Msg.m_ColorBody = g_Config.m_ClDummyColorBody;
@@ -3154,7 +3153,7 @@ void CGameClient::SendDummyInfo(bool Start)
 		CNetMsg_Cl_ChangeInfo Msg;
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
-		Msg.m_Country = m_ChillerBotUX.InsertArbitraryClientFlagInCountry(g_Config.m_ClDummyCountry); // chillerbot modified
+		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_ClDummyCountry); // chillerbot modified
 		Msg.m_pSkin = g_Config.m_ClDummySkin;
 		Msg.m_UseCustomColor = g_Config.m_ClDummyUseCustomColor;
 		Msg.m_ColorBody = g_Config.m_ClDummyColorBody;


### PR DESCRIPTION
Instead of inserting a weird byte, send directly a invalid country when joining and reset it to normal country after a little time.

doing this since reading country flag the previous way (ignoring the byte) was giving a wrong flag, while on this way there are more possible IDs for other clients than just 255 (char limit vs int limit)

M0REKZ/ddnet-custom-clients#3
