### PR TITLE
Update way to identify clients

### DIFF
--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -182,22 +182,22 @@ int CChillerBotUX::GetPlayTimeHours() const
 // function originally from Kaizo Client by +KZ, credit if used
 int CChillerBotUX::InsertCustomClientIdIntoSkinColor(int Color)
 {
-    if(!g_Config.m_ClSendClientType)
-    {
-        return Color;
-    }
+	if(!g_Config.m_ClSendClientType)
+	{
+		return Color;
+	}
 
-    union
-    {
-        int c = 0;
-        unsigned char b[4];
-    } a;
+	union
+	{
+		int m_C = 0;
+		unsigned char m_B[4];
+	} Temp;
 
-    a.c = Color;
+	Temp.m_C = Color;
 
-    //alpha is unused
-    a.b[3] = (unsigned char)CCID_COLOR_BODY_CHILLERBOTUX;
-    Color = a.c;
+	//alpha is unused
+	Temp.m_B[3] = (unsigned char)CCID_COLOR_BODY_CHILLERBOTUX;
+	Color = Temp.m_C;
 
 	return Color;
 }
@@ -225,37 +225,37 @@ int CChillerBotUX::HandleClientCountry(int Country, int ClientId)
 void CChillerBotUX::HandleNewSnapshot(const IClient::CSnapItem *pItem)
 {
 	if(pItem->m_Type == NETOBJTYPE_CLIENTINFO)
-    {
-        const CNetObj_ClientInfo *pInfo = (const CNetObj_ClientInfo *)pItem->m_pData;
+	{
+		const CNetObj_ClientInfo *pInfo = (const CNetObj_ClientInfo *)pItem->m_pData;
 		int ClientId = pItem->m_Id;
 		if(ClientId < MAX_CLIENTS && ClientId >= 0)
 		{
-			CChillerClientData * pClient = &m_aClientData[ClientId];
+			CChillerClientData *pClient = &m_aClientData[ClientId];
 
-            // identify clients
+			// identify clients
 			// code originally from Kaizo Client by +KZ, credit if used
-            union
-            {
-                int c = 0;
-                unsigned char b[4];
-            } a;
+			union
+			{
+				int m_C = 0;
+				unsigned char m_B[4];
+			} Temp;
 
-            a.c = pInfo->m_ColorBody;
+			Temp.m_C = pInfo->m_ColorBody;
 
-            if(a.b[3] == CCID_COLOR_BODY_KAIZO_CLIENT)
-            {
-                pClient->m_CustomClient = CUSTOM_CLIENT_ID_KAIZO_NETWORK;
-            }
-            else if(a.b[3] == CCID_COLOR_BODY_CHILLERBOTUX)
-            {
-                pClient->m_CustomClient = CUSTOM_CLIENT_ID_CHILLERBOTUX;
-            }
-            else if(a.b[3] == CCID_COLOR_BODY_PDUCKCLIENT)
-            {
-                pClient->m_CustomClient = CUSTOM_CLIENT_ID_PDUCKCLIENT;
-            }
-        }
-    }
+			if(Temp.m_B[3] == CCID_COLOR_BODY_KAIZO_CLIENT)
+			{
+				pClient->m_CustomClient = CUSTOM_CLIENT_ID_KAIZO_NETWORK;
+			}
+			else if(Temp.m_B[3] == CCID_COLOR_BODY_CHILLERBOTUX)
+			{
+				pClient->m_CustomClient = CUSTOM_CLIENT_ID_CHILLERBOTUX;
+			}
+			else if(Temp.m_B[3] == CCID_COLOR_BODY_PDUCKCLIENT)
+			{
+				pClient->m_CustomClient = CUSTOM_CLIENT_ID_PDUCKCLIENT;
+			}
+		}
+	}
 }
 
 void CChillerBotUX::PrintPlaytime()

--- a/src/game/client/components/chillerbot/chillerbotux.cpp
+++ b/src/game/client/components/chillerbot/chillerbotux.cpp
@@ -164,63 +164,12 @@ void CChillerBotUX::OnStateChange(int NewState, int OldState)
 	}
 }
 
-void CChillerBotUX::OnUpdate()
-{
-	bool MustSendCustomClient = false;
-
-	for(auto &Client : GameClient()->m_aClients)
-	{
-		if(Client.m_Active)
-		{
-			if(IsOurClientId(Client.ClientId()))
-			{
-				m_aClientData[Client.ClientId()].m_CustomClient = CUSTOM_CLIENT_ID_CHILLERBOTUX; //force chillerbot client for us
-			}
-
-			if(!m_aClientData[Client.ClientId()].m_SentCustomClient)
-			{
-				MustSendCustomClient = true;
-				m_aClientData[Client.ClientId()].m_SentCustomClient = true;
-			}
-		}
-		else
-		{
-			m_aClientData[Client.ClientId()].m_SentCustomClient = false;
-		}
-	}
-
-	if(MustSendCustomClient)
-	{
-		m_SendingCustomClientTicks = 25;
-	}
-
-	switch(m_SendingCustomClientTicks)
-	{
-	case 25:
-		GameClient()->SendInfo(false);
-		GameClient()->SendDummyInfo(false);
-		m_SendingCustomClientTicks = 24;
-		break;
-	case 0:
-		GameClient()->SendInfo(false);
-		GameClient()->SendDummyInfo(false);
-		m_SendingCustomClientTicks = -1;
-		break;
-	default:
-		if(m_SendingCustomClientTicks > 0)
-			m_SendingCustomClientTicks--;
-		break;
-	}
-}
-
 void CChillerBotUX::OnReset()
 {
 	for(auto &ClientData : m_aClientData)
 	{
 		ClientData.Reset();
 	}
-
-	m_SendingCustomClientTicks = 25;
 }
 
 int CChillerBotUX::GetPlayTimeHours() const
@@ -230,22 +179,27 @@ int CChillerBotUX::GetPlayTimeHours() const
 	return m_PlaytimeMinutes / 60;
 }
 
-// function originally from Kaizo Network by +KZ, credit if used
-int CChillerBotUX::ReplaceCountryFlagWithCustomClientId(int Country)
+// function originally from Kaizo Client by +KZ, credit if used
+int CChillerBotUX::InsertCustomClientIdIntoSkinColor(int Color)
 {
-	if(!g_Config.m_ClSendClientType)
-		return Country;
+    if(!g_Config.m_ClSendClientType)
+    {
+        return Color;
+    }
 
-	if(m_SendingCustomClientTicks <= 1) //dont send custom flag
-		return Country;
+    union
+    {
+        int c = 0;
+        unsigned char b[4];
+    } a;
 
-	//if some random day amount of flags conflicts with invalid flag, just send normal country
-	if(GameClient()->m_CountryFlags.Num() >= CUSTOM_CLIENT_ID_KAIZO_NETWORK)
-	{
-		return Country;
-	}
+    a.c = Color;
 
-	return CUSTOM_CLIENT_ID_CHILLERBOTUX;
+    //alpha is unused
+    a.b[3] = (unsigned char)CCID_COLOR_BODY_CHILLERBOTUX;
+    Color = a.c;
+
+	return Color;
 }
 
 // function originally from Kaizo Network by +KZ, credit if used
@@ -266,6 +220,42 @@ int CChillerBotUX::HandleClientCountry(int Country, int ClientId)
 	{
 		return Country;
 	}
+}
+
+void CChillerBotUX::HandleNewSnapshot(const IClient::CSnapItem *pItem)
+{
+	if(pItem->m_Type == NETOBJTYPE_CLIENTINFO)
+    {
+        const CNetObj_ClientInfo *pInfo = (const CNetObj_ClientInfo *)pItem->m_pData;
+		int ClientId = pItem->m_Id;
+		if(ClientId < MAX_CLIENTS && ClientId >= 0)
+		{
+			CChillerClientData * pClient = &m_aClientData[ClientId];
+
+            // identify clients
+			// code originally from Kaizo Client by +KZ, credit if used
+            union
+            {
+                int c = 0;
+                unsigned char b[4];
+            } a;
+
+            a.c = pInfo->m_ColorBody;
+
+            if(a.b[3] == CCID_COLOR_BODY_KAIZO_CLIENT)
+            {
+                pClient->m_CustomClient = CUSTOM_CLIENT_ID_KAIZO_NETWORK;
+            }
+            else if(a.b[3] == CCID_COLOR_BODY_CHILLERBOTUX)
+            {
+                pClient->m_CustomClient = CUSTOM_CLIENT_ID_CHILLERBOTUX;
+            }
+            else if(a.b[3] == CCID_COLOR_BODY_PDUCKCLIENT)
+            {
+                pClient->m_CustomClient = CUSTOM_CLIENT_ID_PDUCKCLIENT;
+            }
+        }
+    }
 }
 
 void CChillerBotUX::PrintPlaytime()
@@ -1508,7 +1498,6 @@ int CChillerBotUX::GetUnusedJumps()
 void CChillerBotUX::CChillerClientData::Reset()
 {
 	m_CustomClient = 0;
-	m_SentCustomClient = false;
 }
 
 bool CChillerBotUX::IsOurClientId(int ClientId)

--- a/src/game/client/components/chillerbot/chillerbotux.h
+++ b/src/game/client/components/chillerbot/chillerbotux.h
@@ -115,7 +115,6 @@ class CChillerBotUX : public CComponent
 	bool OnCursorMove(float x, float y, IInput::ECursorType CursorType) override;
 	bool OnInput(const IInput::CEvent &Event) override;
 	void OnStateChange(int NewState, int OldState) override;
-	void OnUpdate() override;
 	void OnReset() override;
 
 	static void ConPlaytime(IConsole::IResult *pResult, void *pUserData);
@@ -141,7 +140,6 @@ public:
 	{
 	public:
 		int m_CustomClient = 0; //chillerbot
-		bool m_SentCustomClient = false; //chillerbot
 
 		void Reset();
 
@@ -188,10 +186,10 @@ public:
 	int GetUnusedJumps();
 	int GetPlayTimeHours() const;
 
-	int ReplaceCountryFlagWithCustomClientId(int Country);
+	int InsertCustomClientIdIntoSkinColor(int Color);
 	bool IsCustomClientId(int Country);
-	int m_SendingCustomClientTicks = -1;
 	int HandleClientCountry(int Country, int ClientId);
+	void HandleNewSnapshot(const IClient::CSnapItem *pItem);
 
 	// returns true if `ClientId`
 	// matches our current or our dummies current client id

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1789,7 +1789,7 @@ void CGameClient::OnNewSnapshot()
 						str_copy(pClient->m_aName, "nameless tee");
 					}
 					IntsToStr(pInfo->m_aClan, std::size(pInfo->m_aClan), pClient->m_aClan, std::size(pClient->m_aClan));
-					pClient->m_Country = m_ChillerBotUX.HandleClientCountry(pInfo->m_Country, ClientId);
+					pClient->m_Country = m_ChillerBotUX.HandleClientCountry(pInfo->m_Country, ClientId); //keep this to identify previous clients
 
 					IntsToStr(pInfo->m_aSkin, std::size(pInfo->m_aSkin), pClient->m_aSkinName, std::size(pClient->m_aSkinName));
 					if(!CSkin::IsValidName(pClient->m_aSkinName) ||
@@ -2100,6 +2100,7 @@ void CGameClient::OnNewSnapshot()
 				m_MapBestTimeSeconds = pMapBestTimeData->m_MapBestTimeSeconds;
 				m_MapBestTimeMillis = pMapBestTimeData->m_MapBestTimeMillis;
 			}
+			m_ChillerBotUX.HandleNewSnapshot(&Item);
 		}
 	}
 
@@ -3127,7 +3128,7 @@ void CGameClient::SendStartInfo7(bool Dummy)
 	protocol7::CNetMsg_Cl_StartInfo Msg;
 	Msg.m_pName = Dummy ? Client()->DummyName() : Client()->PlayerName();
 	Msg.m_pClan = Dummy ? Config()->m_ClDummyClan : Config()->m_PlayerClan;
-	Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(Dummy ? Config()->m_ClDummyCountry : Config()->m_PlayerCountry); // chillerbot modified
+	Msg.m_Country = Dummy ? Config()->m_ClDummyCountry : Config()->m_PlayerCountry;
 	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
 	{
 		Msg.m_apSkinPartNames[p] = CSkins7::ms_apSkinVariables[(int)Dummy][p];
@@ -3212,10 +3213,10 @@ void CGameClient::SendInfo(bool Start)
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
-		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_PlayerCountry); // chillerbot modified
+		Msg.m_Country = g_Config.m_PlayerCountry;
 		Msg.m_pSkin = g_Config.m_ClPlayerSkin;
 		Msg.m_UseCustomColor = g_Config.m_ClPlayerUseCustomColor;
-		Msg.m_ColorBody = g_Config.m_ClPlayerColorBody;
+		Msg.m_ColorBody = m_ChillerBotUX.InsertCustomClientIdIntoSkinColor(g_Config.m_ClPlayerColorBody); // chillerbot modified
 		Msg.m_ColorFeet = g_Config.m_ClPlayerColorFeet;
 		CMsgPacker Packer(&Msg);
 		Msg.Pack(&Packer);
@@ -3227,10 +3228,10 @@ void CGameClient::SendInfo(bool Start)
 		CNetMsg_Cl_ChangeInfo Msg;
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
-		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_PlayerCountry); // chillerbot modified
+		Msg.m_Country = g_Config.m_PlayerCountry;
 		Msg.m_pSkin = g_Config.m_ClPlayerSkin;
 		Msg.m_UseCustomColor = g_Config.m_ClPlayerUseCustomColor;
-		Msg.m_ColorBody = g_Config.m_ClPlayerColorBody;
+		Msg.m_ColorBody = m_ChillerBotUX.InsertCustomClientIdIntoSkinColor(g_Config.m_ClPlayerColorBody); // chillerbot modified
 		Msg.m_ColorFeet = g_Config.m_ClPlayerColorFeet;
 		CMsgPacker Packer(&Msg);
 		Msg.Pack(&Packer);
@@ -3254,10 +3255,10 @@ void CGameClient::SendDummyInfo(bool Start)
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
-		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_ClDummyCountry); // chillerbot modified
+		Msg.m_Country = g_Config.m_ClDummyCountry;
 		Msg.m_pSkin = g_Config.m_ClDummySkin;
 		Msg.m_UseCustomColor = g_Config.m_ClDummyUseCustomColor;
-		Msg.m_ColorBody = g_Config.m_ClDummyColorBody;
+		Msg.m_ColorBody = m_ChillerBotUX.InsertCustomClientIdIntoSkinColor(g_Config.m_ClDummyColorBody); // chillerbot modified
 		Msg.m_ColorFeet = g_Config.m_ClDummyColorFeet;
 		CMsgPacker Packer(&Msg);
 		Msg.Pack(&Packer);
@@ -3269,10 +3270,10 @@ void CGameClient::SendDummyInfo(bool Start)
 		CNetMsg_Cl_ChangeInfo Msg;
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
-		Msg.m_Country = m_ChillerBotUX.ReplaceCountryFlagWithCustomClientId(g_Config.m_ClDummyCountry); // chillerbot modified
+		Msg.m_Country = g_Config.m_ClDummyCountry;
 		Msg.m_pSkin = g_Config.m_ClDummySkin;
 		Msg.m_UseCustomColor = g_Config.m_ClDummyUseCustomColor;
-		Msg.m_ColorBody = g_Config.m_ClDummyColorBody;
+		Msg.m_ColorBody = m_ChillerBotUX.InsertCustomClientIdIntoSkinColor(g_Config.m_ClDummyColorBody); // chillerbot modified
 		Msg.m_ColorFeet = g_Config.m_ClDummyColorFeet;
 		CMsgPacker Packer(&Msg);
 		Msg.Pack(&Packer);


### PR DESCRIPTION

Instead of doing weird things with country flags, do different weird things (xd) in skin color to notify others we are using chillerbot-ux

This is the way actually used in Kaizo Client (https://github.com/M0REKZ/ddnet-custom-clients/blob/1ab33e9a8105f1c926beec4f82f945834451da6b/custom_clients_ids.h#L24), you may want to keep country detection for the previous client versions though

I did this since i noticed the previous way was giving connection problems to some users in Kaizo Client.. so yeah im sending this update here too

- [x] Tested the change ingame